### PR TITLE
Added way to set msbuild as default

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,6 +2,9 @@
 title Building C++ Program
 echo Building Program...
 echo Shell: CMD
+
+if exist default-msbuild.txt goto msBuild
+
 :findmingw
 set mingwPath=0
 if exist "C:\MinGW" (


### PR DESCRIPTION
Since build.bat uses GCC as default I wanted to add the option to set msbuild as default instead I made the file look for a file called "msbuild-default.txt" and if it's there, it will use MSBuild automatically.